### PR TITLE
update due to sfbrigade moving off github pages

### DIFF
--- a/wordpress_content.html
+++ b/wordpress_content.html
@@ -125,13 +125,13 @@
                     <!-- Code for Bank On San Francisco Wordpress content -->
                     <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8/themes/base/jquery-ui.css" />
                     <link href="source/bootstrap-combined.min.css" rel="stylesheet">
-                    <script type="text/javascript" src="http://codeforsanfrancisco.org/SFOFE-BankOn/source/jquery.js"></script>
-                    <script type="text/javascript" src="http://codeforsanfrancisco.org/SFOFE-BankOn/source/bootstrap.js"></script>
+                    <script type="text/javascript" src="http://old.codeforsanfrancisco.org/SFOFE-BankOn/source/jquery.js"></script>
+                    <script type="text/javascript" src="http://old.codeforsanfrancisco.org/SFOFE-BankOn/source/bootstrap.js"></script>
                     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js"></script>
-                    <script type="text/javascript" src="http://codeforsanfrancisco.org/SFOFE-BankOn/source/jquery.address.min.js"></script>
+                    <script type="text/javascript" src="http://old.codeforsanfrancisco.org/SFOFE-BankOn/source/jquery.address.min.js"></script>
                     <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false&amp;libraries=places"></script>
-                    <script type="text/javascript" src="http://codeforsanfrancisco.org/SFOFE-BankOn/source/jquery.geocomplete.min.js"></script>
-                    <script type="text/javascript" src="http://codeforsanfrancisco.org/SFOFE-BankOn/source/maps_lib.js"></script>
+                    <script type="text/javascript" src="http://old.codeforsanfrancisco.org/SFOFE-BankOn/source/jquery.geocomplete.min.js"></script>
+                    <script type="text/javascript" src="http://old.codeforsanfrancisco.org/SFOFE-BankOn/source/maps_lib.js"></script>
                     <script type="text/javascript" src="http://bankonsanfrancisco.com/wp-content/themes/sf_bankon_v1/js/jquery.fancybox-1.3.4.pack.js"></script>
                     <div style="background: #eee;" class="tw-bs" id="map">
                         <div class="row">


### PR DESCRIPTION
From
http://codeforsanfrancisco.org/SFOFE-BankOn/source/bootstrap.js
to
http://old.codeforsanfrancisco.org/SFOFE-BankOn/source/bootstrap.js

for lots of things.
